### PR TITLE
Fix conditional to enable --no-vis option to work properly

### DIFF
--- a/main.py
+++ b/main.py
@@ -238,7 +238,7 @@ def main():
                        final_rewards.min(),
                        final_rewards.max(), -dist_entropy.data[0],
                        value_loss.data[0], action_loss.data[0]))
-        if j % args.vis_interval == 0:
+        if args.vis and j % args.vis_interval == 0:
             win = visdom_plot(viz, win, args.log_dir, args.env_name, args.algo)
 
 


### PR DESCRIPTION
Currently, the `--no-vis` option fails with:

```
Traceback (most recent call last):
  File "main.py", line 248, in <module>
    main()
  File "main.py", line 244, in main
    win = visdom_plot(viz, win, args.log_dir, args.env_name, args.algo)
UnboundLocalError: local variable 'viz' referenced before assignment
```