### PR TITLE
Fix layer size in DiagGaussian

### DIFF
--- a/distributions.py
+++ b/distributions.py
@@ -41,7 +41,7 @@ class Categorical(nn.Module):
 class DiagGaussian(nn.Module):
     def __init__(self, num_inputs, num_outputs):
         super(DiagGaussian, self).__init__()
-        self.fc_mean = nn.Linear(64, num_outputs)
+        self.fc_mean = nn.Linear(num_inputs, num_outputs)
         self.logstd = AddBias(torch.zeros(num_outputs))
 
     def forward(self, x):


### PR DESCRIPTION
I believe this is a bug. Ran into it running the CNN policy on an environment with continuous actions. You have a number of values which are hardcoded (eg: layer sizes) when they should be based on the input/output size.