### PR TITLE
Made WrapPyTorch get obs space shape from env

### DIFF
--- a/envs.py
+++ b/envs.py
@@ -33,8 +33,8 @@ class WrapPyTorch(gym.ObservationWrapper):
         super(WrapPyTorch, self).__init__(env)
         obs_shape = self.observation_space.shape
         self.observation_space = Box(
-            0.0,
-            1.0,
+            self.observation_space.low[0,0,0],
+            self.observation_space.high[0,0,0],
             [obs_shape[2], obs_shape[1], obs_shape[0]]
         )
 

--- a/envs.py
+++ b/envs.py
@@ -31,7 +31,12 @@ def make_env(env_id, seed, rank, log_dir):
 class WrapPyTorch(gym.ObservationWrapper):
     def __init__(self, env=None):
         super(WrapPyTorch, self).__init__(env)
-        self.observation_space = Box(0.0, 1.0, [1, 84, 84])
+        obs_shape = self.observation_space.shape
+        self.observation_space = Box(
+            0.0,
+            1.0,
+            [obs_shape[2], obs_shape[1], obs_shape[0]]
+        )
 
     def _observation(self, observation):
         return observation.transpose(2, 0, 1)


### PR DESCRIPTION
WrapPyTorch has sizes specific to atari envs baked in. Getting the shape from the wrapped environment allows it to work with other observation image sizes.