### PR TITLE
Using MLP model for small inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import copy
 import glob
 import os
 import time
+import operator
+from functools import reduce
 
 import gym
 import numpy as np
@@ -68,12 +70,14 @@ def main():
     obs_shape = envs.observation_space.shape
     obs_shape = (obs_shape[0] * args.num_stack, *obs_shape[1:])
 
-    if len(envs.observation_space.shape) == 3:
+    obs_numel = reduce(operator.mul, obs_shape, 1)
+
+    if len(obs_shape) == 3 and obs_numel > 1024:
         actor_critic = CNNPolicy(obs_shape[0], envs.action_space, args.recurrent_policy)
     else:
         assert not args.recurrent_policy, \
             "Recurrent policy is not implemented for the MLP controller"
-        actor_critic = MLPPolicy(obs_shape[0], envs.action_space)
+        actor_critic = MLPPolicy(obs_numel, envs.action_space)
 
     if envs.action_space.__class__.__name__ == "Discrete":
         action_shape = 1

--- a/model.py
+++ b/model.py
@@ -1,9 +1,10 @@
+import operator
+from functools import reduce
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from distributions import Categorical, DiagGaussian
 from utils import orthogonal
-
 
 def weights_init(m):
     classname = m.__class__.__name__
@@ -164,6 +165,9 @@ class MLPPolicy(FFPolicy):
             self.dist.fc_mean.weight.data.mul_(0.01)
 
     def forward(self, inputs, states, masks):
+        batch_numel = reduce(operator.mul, inputs.size()[1:], 1)
+        inputs = inputs.view(-1, batch_numel)
+
         x = self.v_fc1(inputs)
         x = F.tanh(x)
 


### PR DESCRIPTION
My environment produces an output of shape (7, 7, 3). For this input size, it doesn't really make sense to use a CNN. It's also problematic because the current CNN code only works if the shape has exactly the image size produced by the atari environments. Hence, I propose this change. For small observations, even if they have 3 input dimensions, the MLP model can be used instead of a CNN.