### PR TITLE
Added linear schedule for learning rate

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -57,6 +57,8 @@ def get_args():
                         help='disables CUDA training')
     parser.add_argument('--recurrent-policy', action='store_true', default=False,
                         help='use a recurrent policy')
+    parser.add_argument('--lr-schedule', action='store_true', default=False,
+                        help='use a linear schedule on the learning rate')
     parser.add_argument('--no-vis', action='store_true', default=False,
                         help='disables visdom visualization')
     args = parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ def main():
     start = time.time()
     for j in range(num_updates):
 
-        if args.lr_schedule:
+        if args.use_linear_lr_decay:
             # decrease learning rate linearly
             if args.algo == "acktr":
                 # use optimizer's learning rate since it's hard-coded in kfac.py

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from kfac import KFACOptimizer
 from model import CNNPolicy, MLPPolicy
 from storage import RolloutStorage
 from visualize import visdom_plot
+from utils import update_linear_schedule
 
 args = get_args()
 
@@ -115,6 +116,14 @@ def main():
 
     start = time.time()
     for j in range(num_updates):
+
+        # decrease learning rate linearly
+        if args.algo == "acktr":
+            # use optimizer's learning rate since it's hard-coded in kfac.py
+            update_linear_schedule(optimizer, j, num_updates, optimizer.lr)
+        else:
+            update_linear_schedule(optimizer, j, num_updates, args.lr)
+
         for step in range(args.num_steps):
             # Sample actions
             value, action, action_log_prob, states = actor_critic.act(Variable(rollouts.observations[step], volatile=True),

--- a/main.py
+++ b/main.py
@@ -100,9 +100,9 @@ def main():
             # decrease learning rate linearly
             if args.algo == "acktr":
                 # use optimizer's learning rate since it's hard-coded in kfac.py
-                update_linear_schedule(optimizer, j, num_updates, optimizer.lr)
+                update_linear_schedule(agent.optimizer, j, num_updates, agent.optimizer.lr)
             else:
-                update_linear_schedule(optimizer, j, num_updates, args.lr)
+                update_linear_schedule(agent.optimizer, j, num_updates, args.lr)
 
         for step in range(args.num_steps):
             # Sample actions

--- a/main.py
+++ b/main.py
@@ -117,12 +117,13 @@ def main():
     start = time.time()
     for j in range(num_updates):
 
-        # decrease learning rate linearly
-        if args.algo == "acktr":
-            # use optimizer's learning rate since it's hard-coded in kfac.py
-            update_linear_schedule(optimizer, j, num_updates, optimizer.lr)
-        else:
-            update_linear_schedule(optimizer, j, num_updates, args.lr)
+        if args.lr_schedule:
+            # decrease learning rate linearly
+            if args.algo == "acktr":
+                # use optimizer's learning rate since it's hard-coded in kfac.py
+                update_linear_schedule(optimizer, j, num_updates, optimizer.lr)
+            else:
+                update_linear_schedule(optimizer, j, num_updates, args.lr)
 
         for step in range(args.num_steps):
             # Sample actions

--- a/utils.py
+++ b/utils.py
@@ -43,3 +43,10 @@ def orthogonal(tensor, gain=1):
     tensor.view_as(q).copy_(q)
     tensor.mul_(gain)
     return tensor
+
+
+def update_linear_schedule(optimizer, epoch, total_num_epochs, initial_lr):
+    """Decreases the learning rate linearly"""
+    lr = initial_lr - (initial_lr * (epoch / float(total_num_epochs)))
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = lr


### PR DESCRIPTION
This attempts to solve #31 
I've added a simple implementation of a linear schedule on the learning rate from an initial value down to 0.
This is mentioned in the ACKTR paper but was missing here.
There is now an argument for toggling it (off by default)

There will be more elegant solutions based on http://pytorch.org/docs/master/_modules/torch/optim/lr_scheduler.html#LambdaLR, but I had trouble implementing this because of an older version of pytorch (0.2).