### PR TITLE
Add support for DeepMind Control Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,101 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Please use this bibtex if you want to cite this repository in your publications:
 * [Atari Learning Environment](https://github.com/mgbellemare/Arcade-Learning-Environment)
 * [MuJoCo](http://mujoco.org)
 * [PyBullet](http://pybullet.org) (including Racecar, Minitaur and Kuka)
+* [DeepMind Control Suite](https://github.com/deepmind/dm_control) (via [dm_control2gym](https://github.com/martinseilair/dm_control2gym))
 
 I highly recommend PyBullet as a free open source alternative to MuJoCo for continuous control tasks.
 
 All environments are operated using exactly the same Gym interface. See their documentations for a comprehensive list.
+
+To use the DeepMind Control Suite environments, set the flag `--env-name dm.<domain_name>.<task_name>`, where `domain_name` and `task_name` are the name of a domain (e.g. `hopper`) and a task within that domain (e.g. `stand`) from the DeepMind Control Suite. Refer to their repo and their [tech report](https://arxiv.org/abs/1801.00690) for a full list of available domains and tasks. Other than setting the task, the API for interacting with the environment is exactly the same as for all the Gym environments thanks to [dm_control2gym](https://github.com/martinseilair/dm_control2gym).
 
 ## Requirements
 

--- a/envs.py
+++ b/envs.py
@@ -6,7 +6,10 @@ from gym.spaces.box import Box
 from baselines import bench
 from baselines.common.atari_wrappers import make_atari, wrap_deepmind
 
-import dm_control2gym
+try:
+    import dm_control2gym
+except ImportError:
+    pass
 
 try:
     import pybullet_envs
@@ -22,7 +25,6 @@ def make_env(env_id, seed, rank, log_dir):
             env = dm_control2gym.make(domain_name=domain, task_name=task)
         else:
             env = gym.make(env_id)
-        # import ipdb; ipdb.set_trace()
         is_atari = hasattr(gym.envs, 'atari') and isinstance(env.unwrapped, gym.envs.atari.atari_env.AtariEnv)
         if is_atari:
             env = make_atari(env_id)

--- a/envs.py
+++ b/envs.py
@@ -9,13 +9,18 @@ from baselines.common.atari_wrappers import make_atari, wrap_deepmind
 try:
     import pybullet_envs
     import roboschool
+    import dm_control2gym
 except ImportError:
     pass
 
 
 def make_env(env_id, seed, rank, log_dir):
     def _thunk():
-        env = gym.make(env_id)
+        if env_id.startswith("dm"):
+            _, domain, task = env_id.split('.')
+            env = dm_control2gym.make(domain_name=domain, task_name=task)
+        else:
+            env = gym.make(env_id)
         is_atari = hasattr(gym.envs, 'atari') and isinstance(env.unwrapped, gym.envs.atari.atari_env.AtariEnv)
         if is_atari:
             env = make_atari(env_id)

--- a/envs.py
+++ b/envs.py
@@ -6,10 +6,11 @@ from gym.spaces.box import Box
 from baselines import bench
 from baselines.common.atari_wrappers import make_atari, wrap_deepmind
 
+import dm_control2gym
+
 try:
     import pybullet_envs
     import roboschool
-    import dm_control2gym
 except ImportError:
     pass
 
@@ -21,6 +22,7 @@ def make_env(env_id, seed, rank, log_dir):
             env = dm_control2gym.make(domain_name=domain, task_name=task)
         else:
             env = gym.make(env_id)
+        # import ipdb; ipdb.set_trace()
         is_atari = hasattr(gym.envs, 'atari') and isinstance(env.unwrapped, gym.envs.atari.atari_env.AtariEnv)
         if is_atari:
             env = make_atari(env_id)


### PR DESCRIPTION
This PR adds support for the DeepMind Control Suite tasks via dm_control2gym (https://github.com/martinseilair/dm_control2gym).

Use it by specifying an env name in the form `dm.<domain_name>.<task_name>`.