### PR TITLE
Improve readability of policy act method

### DIFF
--- a/algo/ppo.py
+++ b/algo/ppo.py
@@ -14,7 +14,7 @@ class PPO(object):
                  lr=None,
                  eps=None,
                  max_grad_norm=None):
-        
+
         self.actor_critic = actor_critic
 
         self.clip_param = clip_param
@@ -74,7 +74,7 @@ class PPO(object):
                 value_loss_epoch += value_loss.item()
                 action_loss_epoch += action_loss.item()
                 dist_entropy_epoch += dist_entropy.item()
-                
+
         num_updates = self.ppo_epoch * self.num_mini_batch
 
         value_loss_epoch /= num_updates

--- a/distributions.py
+++ b/distributions.py
@@ -12,7 +12,7 @@ Modify standard PyTorch distributions so they are compatible with this code.
 FixedCategorical = torch.distributions.Categorical
 
 old_sample = FixedCategorical.sample
-FixedCategorical.sample = lambda self: old_sample(self).unsqueeze(-1) 
+FixedCategorical.sample = lambda self: old_sample(self).unsqueeze(-1)
 
 log_prob_cat = FixedCategorical.log_prob
 FixedCategorical.log_probs = lambda self, actions: log_prob_cat(self, actions.squeeze(-1)).unsqueeze(-1)
@@ -48,11 +48,11 @@ class Categorical(nn.Module):
 class DiagGaussian(nn.Module):
     def __init__(self, num_inputs, num_outputs):
         super(DiagGaussian, self).__init__()
-        
+
         init_ = lambda m: init(m,
               init_normc_,
               lambda x: nn.init.constant_(x, 0))
-        
+
         self.fc_mean = init_(nn.Linear(num_inputs, num_outputs))
         self.logstd = AddBias(torch.zeros(num_outputs))
 

--- a/distributions.py
+++ b/distributions.py
@@ -17,7 +17,7 @@ FixedCategorical.sample = lambda self: old_sample(self).unsqueeze(-1)
 log_prob_cat = FixedCategorical.log_prob
 FixedCategorical.log_probs = lambda self, actions: log_prob_cat(self, actions.squeeze(-1)).unsqueeze(-1)
 
-FixedCategorical.mode = lambda self: self.probs.max(-1)[1].unsqueeze(-1)
+FixedCategorical.mode = lambda self: self.probs.argmax(dim=1, keepdim=True)
 
 FixedNormal = torch.distributions.Normal
 log_prob_normal = FixedNormal.log_prob

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ def main():
     obs_shape = (obs_shape[0] * args.num_stack, *obs_shape[1:])
 
     actor_critic = Policy(obs_shape, envs.action_space, args.recurrent_policy)
-    
+
     if envs.action_space.__class__.__name__ == "Discrete":
         action_shape = 1
     else:
@@ -156,7 +156,7 @@ def main():
         rollouts.compute_returns(next_value, args.use_gae, args.gamma, args.tau)
 
         value_loss, action_loss, dist_entropy = agent.update(rollouts)
-        
+
         rollouts.after_update()
 
         if j % args.save_interval == 0 and args.save_dir != "":

--- a/model.py
+++ b/model.py
@@ -21,7 +21,7 @@ class Policy(nn.Module):
             self.base = MLPBase(obs_shape[0])
         else:
             raise NotImplementedError
-        
+
         if action_space.__class__.__name__ == "Discrete":
             num_outputs = action_space.n
             self.dist = Categorical(self.base.output_size, num_outputs)
@@ -30,7 +30,7 @@ class Policy(nn.Module):
             self.dist = DiagGaussian(self.base.output_size, num_outputs)
         else:
             raise NotImplementedError
-        
+
         self.state_size = self.base.state_size
 
     def forward(self, inputs, states, masks):
@@ -39,21 +39,21 @@ class Policy(nn.Module):
     def act(self, inputs, states, masks, deterministic=False):
         value, actor_features, states = self.base(inputs, states, masks)
         dist = self.dist(actor_features)
-        
+
         if deterministic:
             action = dist.mode()
         else:
             action = dist.sample()
-        
+
         action_log_probs = dist.log_probs(action)
         dist_entropy = dist.entropy().mean()
-        
+
         return value, action, action_log_probs, states
 
-    def get_value(self, inputs, states, masks):        
+    def get_value(self, inputs, states, masks):
         value, _, _ = self.base(inputs, states, masks)
         return value
-    
+
     def evaluate_actions(self, inputs, states, masks, action):
         value, actor_features, states = self.base(inputs, states, masks)
         dist = self.dist(actor_features)
@@ -67,12 +67,12 @@ class Policy(nn.Module):
 class CNNBase(nn.Module):
     def __init__(self, num_inputs, use_gru):
         super(CNNBase, self).__init__()
-        
+
         init_ = lambda m: init(m,
                       nn.init.orthogonal_,
-                      lambda x: nn.init.constant_(x, 0), 
+                      lambda x: nn.init.constant_(x, 0),
                       nn.init.calculate_gain('relu'))
-        
+
         self.main = nn.Sequential(
             init_(nn.Conv2d(num_inputs, 32, 8, stride=4)),
             nn.ReLU(),
@@ -84,14 +84,14 @@ class CNNBase(nn.Module):
             init_(nn.Linear(32 * 7 * 7, 512)),
             nn.ReLU()
         )
-        
+
         if use_gru:
             self.gru = nn.GRUCell(512, 512)
             nn.init.orthogonal_(self.gru.weight_ih.data)
             nn.init.orthogonal_(self.gru.weight_hh.data)
             self.gru.bias_ih.data.fill_(0)
             self.gru.bias_hh.data.fill_(0)
-            
+
         init_ = lambda m: init(m,
           nn.init.orthogonal_,
           lambda x: nn.init.constant_(x, 0))
@@ -110,7 +110,7 @@ class CNNBase(nn.Module):
     @property
     def output_size(self):
         return 512
-        
+
     def forward(self, inputs, states, masks):
         x = self.main(inputs / 255.0)
 
@@ -132,18 +132,18 @@ class CNNBase(nn.Module):
 class MLPBase(nn.Module):
     def __init__(self, num_inputs):
         super(MLPBase, self).__init__()
-        
+
         init_ = lambda m: init(m,
               init_normc_,
               lambda x: nn.init.constant_(x, 0))
-        
+
         self.actor = nn.Sequential(
             init_(nn.Linear(num_inputs, 64)),
             nn.Tanh(),
             init_(nn.Linear(64, 64)),
             nn.Tanh()
         )
-        
+
         self.critic = nn.Sequential(
             init_(nn.Linear(num_inputs, 64)),
             nn.Tanh(),
@@ -158,7 +158,7 @@ class MLPBase(nn.Module):
     @property
     def state_size(self):
         return 1
-    
+
     @property
     def output_size(self):
         return 64

--- a/storage.py
+++ b/storage.py
@@ -40,7 +40,7 @@ class RolloutStorage(object):
         self.value_preds[self.step].copy_(value_pred)
         self.rewards[self.step].copy_(reward)
         self.masks[self.step + 1].copy_(mask)
-        
+
         self.step = (self.step + 1) % self.num_steps
 
     def after_update(self):

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ def init(module, weight_init, bias_init, gain=1):
     bias_init(module.bias.data)
     return module
 
-    
+
 # https://github.com/openai/baselines/blob/master/baselines/common/tf_util.py#L87
 def init_normc_(weight, gain=1):
     weight.normal_(0, 1)


### PR DESCRIPTION
This PR improves the readability of the `FixedCategorical.mode` method refered to in issue #74. In addition, I took the liberty to remove unnecessary tabs and whitespace in multiple files.