### PR TITLE
ppo recurrent check fixed.

### DIFF
--- a/algo/ppo.py
+++ b/algo/ppo.py
@@ -39,7 +39,7 @@ class PPO(object):
         dist_entropy_epoch = 0
 
         for e in range(self.ppo_epoch):
-            if hasattr(self.actor_critic, 'gru'):
+            if hasattr(self.actor_critic.base, 'gru'):
                 data_generator = rollouts.recurrent_generator(
                     advantages, self.num_mini_batch)
             else:


### PR DESCRIPTION
gru is inside self.actor_critic.base, but the earlier check was to see if gru was inside self.actor_critic.

This might have affected recurrent PPO runs till now. Data was not being generated from the recurrent_generator, so the data being fed at each time t would have been incoherent with the other times.

This fix addresses only PPO. Not certain that this does not exist in other algo implementations, but there isn't a straightforward gru check in those algo/kfac.py or algo/a2c_acktr.py.