### PR TITLE
Apply SplitBiases in KFAC only once to a model

### DIFF
--- a/algo/kfac.py
+++ b/algo/kfac.py
@@ -100,7 +100,7 @@ class KFACOptimizer(optim.Optimizer):
 
         def split_bias(module):
             for mname, child in module.named_children():
-                if hasattr(child, 'bias'):
+                if hasattr(child, 'bias') and child.bias is not None:
                     module._modules[mname] = SplitBias(child)
                 else:
                     split_bias(child)


### PR DESCRIPTION
If a model training with KFAC is resumed the algorithm tries to readd the split biases to a layer with a bias parameter. This PR solves this issue.