### PR TITLE
Introduce to device syntax

### DIFF
--- a/algo/a2c_acktr.py
+++ b/algo/a2c_acktr.py
@@ -5,7 +5,7 @@ import torch.optim as optim
 from .kfac import KFACOptimizer
 
 
-class A2C_ACKTR(object):
+class A2C_ACKTR():
     def __init__(self,
                  actor_critic,
                  value_loss_coef,

--- a/algo/ppo.py
+++ b/algo/ppo.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 
-class PPO(object):
+class PPO():
     def __init__(self,
                  actor_critic,
                  clip_param,
@@ -33,7 +33,6 @@ class PPO(object):
         advantages = rollouts.returns[:-1] - rollouts.value_preds[:-1]
         advantages = (advantages - advantages.mean()) / (
             advantages.std() + 1e-5)
-
 
         value_loss_epoch = 0
         action_loss_epoch = 0

--- a/storage.py
+++ b/storage.py
@@ -25,15 +25,15 @@ class RolloutStorage(object):
         self.num_steps = num_steps
         self.step = 0
 
-    def cuda(self):
-        self.obs = self.obs.cuda()
-        self.recurrent_hidden_states = self.recurrent_hidden_states.cuda()
-        self.rewards = self.rewards.cuda()
-        self.value_preds = self.value_preds.cuda()
-        self.returns = self.returns.cuda()
-        self.action_log_probs = self.action_log_probs.cuda()
-        self.actions = self.actions.cuda()
-        self.masks = self.masks.cuda()
+    def to(self, device):
+        self.obs = self.obs.to(device)
+        self.recurrent_hidden_states = self.recurrent_hidden_states.to(device)
+        self.rewards = self.rewards.to(device)
+        self.value_preds = self.value_preds.to(device)
+        self.returns = self.returns.to(device)
+        self.action_log_probs = self.action_log_probs.to(device)
+        self.actions = self.actions.to(device)
+        self.masks = self.masks.to(device)
 
     def insert(self, obs, recurrent_hidden_states, actions, action_log_probs, value_preds, rewards, masks):
         self.obs[self.step + 1].copy_(obs)


### PR DESCRIPTION
This PR introduces two small changes:

1. Add the new `.to(device)` syntax to `RolloutStorage` and `main.py`.
2. Return the weighted value loss and distribution entropy from algorithms. This does not change the optimisation but a more accurate logging of these metrics. In particular if for example `value_loss_coef = 0.0`.