### PR TITLE
ISSUE #123: num_mini_batch fix

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -70,11 +70,6 @@ class RolloutStorage(object):
     def feed_forward_generator(self, advantages, num_mini_batch):
         num_steps, num_processes = self.rewards.size()[0:2]
         batch_size = num_processes * num_steps
-        assert batch_size >= num_mini_batch, (
-            "PPO requires the number of processes ({}) "
-            "* number of steps ({}) = {} "
-            "to be greater than or equal to the number of PPO mini batches ({})."
-            "".format(num_processes, num_steps, num_processes * num_steps, num_mini_batch))
         mini_batch_size = batch_size // num_mini_batch
         sampler = BatchSampler(SubsetRandomSampler(range(batch_size)), mini_batch_size, drop_last=False)
         for indices in sampler:
@@ -92,10 +87,6 @@ class RolloutStorage(object):
 
     def recurrent_generator(self, advantages, num_mini_batch):
         num_processes = self.rewards.size(1)
-        assert num_processes >= num_mini_batch, (
-            "PPO requires the number of processes ({}) "
-            "to be greater than or equal to the number of "
-            "PPO mini batches ({}).".format(num_processes, num_mini_batch))
         num_envs_per_batch = num_processes // num_mini_batch
         perm = torch.randperm(num_processes)
         for start_ind in range(0, num_processes, num_envs_per_batch):


### PR DESCRIPTION
The `assert` statements were incorrectly checking that `batch_size >= num_mini_batch`; instead, the check is `batch_size >= mini_batch_size`. 

But if you just remove these `assert` statements, then the issue should be addressed. `batch_size` will always be >= `mini_batch_size` since `num_mini_batch` is an integer >= 1, and `mini_batch_size = batch_size // num_mini_batch`. If `num_mini_batch` is 0, then a divide by zero exception will get thrown anyways.