### PR TITLE
Add VecNormalize with eval mode and fix previous bug

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,29 @@
 import torch
 import torch.nn as nn
 
+from envs import VecNormalize
+
+
+# Get a render function
+def get_render_func(venv):
+    if hasattr(venv, 'envs'):
+        return venv.envs[0].render
+    elif hasattr(venv, 'venv'):
+        return get_render_func(venv.venv)
+    elif hasattr(venv, 'env'):
+        return get_render_func(venv.env)
+
+    return None
+
+
+def get_vec_normalize(venv):
+    if isinstance(venv, VecNormalize):
+        return venv
+    elif hasattr(venv, 'venv'):
+        return get_vec_normalize(venv.venv)
+
+    return None
+
 
 # Necessary for my KFAC implementation.
 class AddBias(nn.Module):


### PR DESCRIPTION
This PR circumvents the "ugly" hack of adding a manual `obfilt` method by introducing a `VecNormalize` class with eval mode (in analogy to PyTorch model eval mode). In addition, it solves a previous bug in which the check whether the vector environment is a `VecNormalize` class is always false if no `VecPyTorchFrameStack` env is wrapped. (See `make_vec_envs` and the varying number of `.venv` calls necessary to get to the potential `VecNormalize` class.)

Also notice the change of `hasattr` to `getattr` for saving the `ob_rms` and the new `get_render_func` function. In general, I think there should be a better way to reach different environment wrappers but I am currently not aware of any.

@ikostrikov I did some testing of these changes but please double check with your usual testing procedure.