### PR TITLE
Faster recurrent policy evaluate actions

### DIFF
--- a/model.py
+++ b/model.py
@@ -159,7 +159,7 @@ class NNBase(nn.Module):
             x = torch.cat(outputs, dim=0)
             # flatten
             x = x.view(T * N, -1)
-            hxs = hxs.unsqueeze(0)
+            hxs = hxs.squeeze(0)
 
         return x, hxs
 

--- a/model.py
+++ b/model.py
@@ -126,7 +126,6 @@ class NNBase(nn.Module):
                             .squeeze()
                             .cpu())
 
-            # Otherwise, we will need to process the sequence in smaller chunks
 
             # +1 to correct the masks[1:]
             if has_zeros.dim() == 0:

--- a/model.py
+++ b/model.py
@@ -83,10 +83,11 @@ class NNBase(nn.Module):
 
         if recurrent:
             self.gru = nn.GRU(recurrent_input_size, hidden_size)
-            nn.init.orthogonal_(self.gru.weight_ih_l0.data)
-            nn.init.orthogonal_(self.gru.weight_hh_l0.data)
-            self.gru.bias_ih_l0.data.fill_(0)
-            self.gru.bias_hh_l0.data.fill_(0)
+            for name, param in self.gru.named_parameters():
+                if 'bias' in name:
+                    nn.init.constant_(param, 0)
+                elif 'weight' in name:
+                    nn.init.orthogonal_(param)
 
     @property
     def is_recurrent(self):


### PR DESCRIPTION
The currently recurrent policy implementation uses a `GRUCell` and thus a for-loop to evaluate each step in the rollout.  This PR changes the recurrent policy to use a `GRU` (which unfortunately breaks existing pre-trained models) and evaluates the sequence with as few `forward` calls as possible.

In order to reset the hidden state, the `masks` tensor is checked to see if any element has a zero for each step in the rollout (a zero in `masks` corresponds to at a done in the rollout).  If steps `t_1` and `t_2` have at least one done, then steps `t` such that `t_1 <= t < t_2` are run with one call to `forward`.

This results in a massive speed up whenever the number of steps with at least one done is significantly less than the rollout length.  In `PongNoFrameskip-v4` with PPO I see ~1000 FPS while training with this change while I see ~380 FPS with the current implementation.

This does end up being slower if the number of steps with at least one done is very close to the rollout length.  If I artificially set every step to have at least one done, I see ~305 FPS.  If I artificially set every other step to have at least one done, I see ~450 FPS, so the break even is fairly quick.

For `PongNoFrameskip-v4` with A2C, I see ~1860 FPS with this change, and ~1800 FPS with the current implementation.   Due to the longer rollout in PPO, this change is more beneficial for that algorithm, but it doesn't hurt A2C either.

To check if I didn't break anything by doing this, I trained a recurrent policy with PPO in PongNoFrameskip-v4, and the reward curve looks as expected.
![visdom_image](https://user-images.githubusercontent.com/12722529/46248882-ac4a0e00-c3ed-11e8-94da-5e3d0ccb2034.jpg)
