### PR TITLE
Policy with custom base and Bernoulli distribution

### DIFF
--- a/distributions.py
+++ b/distributions.py
@@ -10,17 +10,25 @@ from utils import AddBias, init
 Modify standard PyTorch distributions so they are compatible with this code.
 """
 
+#
+# Standardize distribution interfaces
+#
+
+# Categorical
 FixedCategorical = torch.distributions.Categorical
 
 old_sample = FixedCategorical.sample
 FixedCategorical.sample = lambda self: old_sample(self).unsqueeze(-1)
 
 log_prob_cat = FixedCategorical.log_prob
-FixedCategorical.log_probs = lambda self, actions: log_prob_cat(self, actions.squeeze(-1)).unsqueeze(-1)
+FixedCategorical.log_probs = lambda self, actions: log_prob_cat(self, actions.squeeze(-1)).view(actions.size(0), -1).sum(-1).unsqueeze(-1)
 
-FixedCategorical.mode = lambda self: self.probs.argmax(dim=1, keepdim=True)
+FixedCategorical.mode = lambda self: self.probs.argmax(dim=-1, keepdim=True)
 
+
+# Normal
 FixedNormal = torch.distributions.Normal
+
 log_prob_normal = FixedNormal.log_prob
 FixedNormal.log_probs = lambda self, actions: log_prob_normal(self, actions).sum(-1, keepdim=True)
 
@@ -30,14 +38,25 @@ FixedNormal.entropy = lambda self: entropy(self).sum(-1)
 FixedNormal.mode = lambda self: self.mean
 
 
+# Bernoulli
+FixedBernoulli = torch.distributions.Bernoulli
+
+log_prob_bernoulli = FixedBernoulli.log_prob
+FixedBernoulli.log_probs = lambda self, actions: log_prob_bernoulli(self, actions).view(actions.size(0), -1).sum(-1).unsqueeze(-1)
+
+entropy = FixedBernoulli.entropy
+FixedBernoulli.entropy = lambda self: entropy(self).sum(-1)
+FixedBernoulli.mode = lambda self: torch.gt(self.probs, 0.5).float()
+
+
 class Categorical(nn.Module):
     def __init__(self, num_inputs, num_outputs):
         super(Categorical, self).__init__()
 
         init_ = lambda m: init(m,
-              nn.init.orthogonal_,
-              lambda x: nn.init.constant_(x, 0),
-              gain=0.01)
+            nn.init.orthogonal_,
+            lambda x: nn.init.constant_(x, 0),
+            gain=0.01)
 
         self.linear = init_(nn.Linear(num_inputs, num_outputs))
 
@@ -51,8 +70,8 @@ class DiagGaussian(nn.Module):
         super(DiagGaussian, self).__init__()
 
         init_ = lambda m: init(m,
-              nn.init.orthogonal_,
-              lambda x: nn.init.constant_(x, 0))
+            nn.init.orthogonal_,
+            lambda x: nn.init.constant_(x, 0))
 
         self.fc_mean = init_(nn.Linear(num_inputs, num_outputs))
         self.logstd = AddBias(torch.zeros(num_outputs))
@@ -67,3 +86,18 @@ class DiagGaussian(nn.Module):
 
         action_logstd = self.logstd(zeros)
         return FixedNormal(action_mean, action_logstd.exp())
+
+
+class Bernoulli(nn.Module):
+    def __init__(self, num_inputs, num_outputs):
+        super(Bernoulli, self).__init__()
+
+        init_ = lambda m: init(m,
+            nn.init.orthogonal_,
+            lambda x: nn.init.constant_(x, 0))
+
+        self.linear = init_(nn.Linear(num_inputs, num_outputs))
+
+    def forward(self, x):
+        x = self.linear(x)
+        return FixedBernoulli(logits=x)

--- a/main.py
+++ b/main.py
@@ -16,9 +16,9 @@ from arguments import get_args
 from envs import make_vec_envs
 from model import Policy
 from storage import RolloutStorage
-from utils import get_vec_normalize
 from visualize import visdom_plot
-from utils import update_linear_schedule
+from utils import update_linear_schedule, get_vec_normalize
+
 
 args = get_args()
 
@@ -96,7 +96,7 @@ def main():
     start = time.time()
     for j in range(num_updates):
 
-        if args.use_linear_lr_decay:            
+        if args.use_linear_lr_decay:
             # decrease learning rate linearly
             if args.algo == "acktr":
                 # use optimizer's learning rate since it's hard-coded in kfac.py
@@ -104,9 +104,9 @@ def main():
             else:
                 update_linear_schedule(agent.optimizer, j, num_updates, args.lr)
 
-        if args.algo == 'ppo' and args.use_linear_lr_decay:      
+        if args.algo == 'ppo' and args.use_linear_lr_decay:
             agent.clip_param = args.clip_param  * (1 - j / float(num_updates))
-                
+
         for step in range(args.num_steps):
             # Sample actions
             with torch.no_grad():

--- a/model.py
+++ b/model.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
 
-from distributions import Categorical, DiagGaussian
+from distributions import Categorical, DiagGaussian, Bernoulli
 from utils import init
 
 
@@ -13,17 +13,19 @@ class Flatten(nn.Module):
 
 
 class Policy(nn.Module):
-    def __init__(self, obs_shape, action_space, base_kwargs=None):
+    def __init__(self, obs_shape, action_space, base=None, base_kwargs=None):
         super(Policy, self).__init__()
         if base_kwargs is None:
             base_kwargs = {}
+        if base is None:
+            if len(obs_shape) == 3:
+                base = CNNBase
+            elif len(obs_shape) == 1:
+                base = MLPBase
+            else:
+                raise NotImplementedError
 
-        if len(obs_shape) == 3:
-            self.base = CNNBase(obs_shape[0], **base_kwargs)
-        elif len(obs_shape) == 1:
-            self.base = MLPBase(obs_shape[0], **base_kwargs)
-        else:
-            raise NotImplementedError
+        self.base = base(obs_shape[0], **base_kwargs)
 
         if action_space.__class__.__name__ == "Discrete":
             num_outputs = action_space.n
@@ -31,6 +33,9 @@ class Policy(nn.Module):
         elif action_space.__class__.__name__ == "Box":
             num_outputs = action_space.shape[0]
             self.dist = DiagGaussian(self.base.output_size, num_outputs)
+        elif action_space.__class__.__name__ == "MultiBinary":
+            num_outputs = action_space.shape[0]
+            self.dist = Bernoulli(self.base.output_size, num_outputs)
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
This PR adds four major changes:
1. Add the Bernoulli distribution as suggested in #44. For the mode I just used a 0.5 threshold. I am open for suggestions to improve this little hack.
2. Add the Bernoulli distribution to the `Policy` class.
3. Change https://github.com/ikostrikov/pytorch-a2c-ppo-acktr/blob/669181152ed6e781ff7a25f7f65dd3daf91de6da/distributions.py#L21 to take the argmax of the last (`-1`) dimension.
4. Currently, one has to modify the `Policy` class to use custom base functions other than the preimplemented `MLPBase` and `CNNBase`. The new `base` argument of the `Policy` class allows to inject custom models without any trouble. 
