### PR TITLE
Fixed minor bug in evaluation code

### DIFF
--- a/main.py
+++ b/main.py
@@ -197,8 +197,11 @@ def main():
                 # Obser reward and next obs
                 obs, reward, done, infos = eval_envs.step(action)
 
-                eval_masks = torch.FloatTensor([[0.0] if done_ else [1.0]
-                                                for done_ in done])
+                eval_masks = torch.tensor([[0.0] if done_ else [1.0]
+                                           for done_ in done],
+                                           dtype=torch.float32,
+                                           device=device)
+                
                 for info in infos:
                     if 'episode' in info.keys():
                         eval_episode_rewards.append(info['episode']['r'])


### PR DESCRIPTION
- Fixed  a minor bug in the evaluation code
If the model is on a gpu, `eval_masks` would cause an error since it is not a `torch.cuda.FloatTensor` type.
Instead, it should just be like `torch.tensor(..., dtype=torch.float32, device=device)`.